### PR TITLE
feat(culture): person count per category

### DIFF
--- a/pb/pb_migrations/1776420445_created_person_count_per_category.js
+++ b/pb/pb_migrations/1776420445_created_person_count_per_category.js
@@ -1,0 +1,59 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  // View returning one row per (category, role) pair with person counts.
+  // Admin users aggregate all role rows client-side.
+  const collection = new Collection({
+    "id": "pbc_5001000002",
+    "name": "person_count_per_category",
+    "type": "view",
+    "listRule": "@request.auth.id != ''",
+    "viewRule": null,
+    "viewQuery": "SELECT (cat.value || '_' || role.value) AS id, cat.value AS category_id, role.value AS role_id, COUNT(p.id) AS person_count FROM person p, json_each(p.Category) cat, json_each(p.Roles) role GROUP BY cat.value, role.value HAVING COUNT(p.id) > 0",
+    "fields": [
+      {
+        "hidden": false,
+        "id": "text3208210257",
+        "max": 0,
+        "min": 0,
+        "name": "id",
+        "pattern": "^[a-z0-9_]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "text5001000003",
+        "name": "category_id",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "text5001000004",
+        "name": "role_id",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "number5001000002",
+        "name": "person_count",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "number"
+      }
+    ]
+  });
+
+  return app.save(collection);
+}, (app) => {
+  return app.delete(app.findCollectionByNameOrId("pbc_5001000002"));
+})

--- a/src/components/culture/app.vue
+++ b/src/components/culture/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-view :categories="categories"></router-view>
+  <router-view :categories="categories" :category-counts="categoryCounts" entity-label="personne"></router-view>
 </template>
 
 <script setup lang="ts">
@@ -8,8 +8,9 @@ import router from './router'
 import useAuth from '@admin/composables/useAuth'
 import type { TCategory } from '../../types'
 
-const { pb, isAuthenticated } = useAuth()
+const { pb, isAuthenticated, isAdmin, roles } = useAuth()
 const categories = ref<TCategory.TRecord[]>([])
+const categoryCounts = ref<Record<string, number>>({})
 
 onMounted(async () => {
   if (!isAuthenticated.value) {
@@ -25,12 +26,35 @@ onMounted(async () => {
   })
   app.use(router)
 
-  const raw = await pb.collection<TCategory.TRecord>('category').getFullList({
+  const categoriesPromise = pb.collection<TCategory.TRecord>('category').getFullList({
     fields: 'id, tag, slug, expand.category_via_Parent.*',
     sort: 'tag',
     filter: 'Parent = null',
     expand: 'category_via_Parent',
   })
+
+  const countsPromise = isAdmin.value
+    ? pb.collection('person').getFullList({ fields: 'Category', requestKey: null })
+    : pb.collection('person_count_per_category').getFullList({ requestKey: null })
+
+  const [raw, counts] = await Promise.all([categoriesPromise, countsPromise])
+
+  const countsMap: Record<string, number> = {}
+  if (isAdmin.value) {
+    ;(counts as any[]).forEach(person => {
+      ;(person.Category ?? []).forEach((catId: string) => {
+        countsMap[catId] = (countsMap[catId] ?? 0) + 1
+      })
+    })
+  } else {
+    const userRoleIds = roles.value.map((r: any) => r.id)
+    ;(counts as any[]).forEach(row => {
+      if (userRoleIds.includes(row.role_id)) {
+        countsMap[row.category_id] = (countsMap[row.category_id] ?? 0) + row.person_count
+      }
+    })
+  }
+  categoryCounts.value = countsMap
 
   categories.value = raw
     .map(parentCat => {

--- a/src/components/lexique/CategoriesGrid.vue
+++ b/src/components/lexique/CategoriesGrid.vue
@@ -30,7 +30,7 @@
     </div>
 
     <!-- Grille des sous-catégories -->
-    <router-view :categories="categories" :category-counts="categoryCounts"></router-view>
+    <router-view :categories="categories" :category-counts="categoryCounts" :entity-label="entityLabel"></router-view>
   </div>
 </template>
 
@@ -42,6 +42,7 @@ import { useRoute, useRouter } from 'vue-router'
 const props = defineProps<{
   categories: TCategory.TRecord[]
   categoryCounts?: Record<string, number>
+  entityLabel?: string
 }>()
 const router = useRouter()
 const route = useRoute()
@@ -50,7 +51,11 @@ const activeParent = ref<string>(route.params.category as string)
 const parentCategories = computed(() => props.categories.filter(cat => !cat.Parent))
 const parent = computed(() => props.categories.find(cat => cat.slug === activeParent.value))
 
-const signLabel = (count: number) => `${count} ${count === 1 ? 'signe' : 'signes'}`
+const signLabel = (count: number) => {
+  const label = props.entityLabel ?? 'signe'
+  const plural = props.entityLabel ? `${label}s` : 'signes'
+  return `${count} ${count === 1 ? label : plural}`
+}
 
 const parentCount = (cat: TCategory.TRecord): number =>
   (cat.expand?.category_via_Parent ?? []).reduce(

--- a/src/components/lexique/CategoriesGrid.vue
+++ b/src/components/lexique/CategoriesGrid.vue
@@ -22,7 +22,7 @@
       >
         <div class="card-body items-center justify-center p-4 gap-2">
           <h2 class="card-title text-xl md:text-2xl text-center">{{ cat.tag }}</h2>
-          <span class="badge badge-sm bg-base-content/10 border-0">
+          <span v-if="categoryCounts" class="badge badge-sm bg-base-content/10 border-0">
             {{ signLabel(parentCount(cat)) }}
           </span>
         </div>
@@ -41,7 +41,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 const props = defineProps<{
   categories: TCategory.TRecord[]
-  categoryCounts: Record<string, number>
+  categoryCounts?: Record<string, number>
 }>()
 const router = useRouter()
 const route = useRoute()
@@ -54,13 +54,14 @@ const signLabel = (count: number) => `${count} ${count === 1 ? 'signe' : 'signes
 
 const parentCount = (cat: TCategory.TRecord): number =>
   (cat.expand?.category_via_Parent ?? []).reduce(
-    (sum: number, subCat: TCategory.TRecord) => sum + (props.categoryCounts[subCat.id] ?? 0),
+    (sum: number, subCat: TCategory.TRecord) => sum + (props.categoryCounts?.[subCat.id] ?? 0),
     0,
   )
 
-const visibleParentCategories = computed(() =>
-  parentCategories.value.filter(cat => parentCount(cat) > 0),
-)
+const visibleParentCategories = computed(() => {
+  if (!props.categoryCounts) return parentCategories.value
+  return parentCategories.value.filter(cat => parentCount(cat) > 0)
+})
 
 function toggleParent(slug: string) {
   activeParent.value = activeParent.value === slug ? '' : slug

--- a/src/components/lexique/Category.vue
+++ b/src/components/lexique/Category.vue
@@ -45,13 +45,18 @@ const props = defineProps<{
   category: string
   categories: TCategory.TRecord[]
   categoryCounts?: Record<string, number>
+  entityLabel?: string
 }>()
 const router = useRouter()
 const route = useRoute()
 
 const activeSubcategory = ref()
 
-const signLabel = (count: number) => `${count} ${count === 1 ? 'signe' : 'signes'}`
+const signLabel = (count: number) => {
+  const label = props.entityLabel ?? 'signe'
+  const plural = props.entityLabel ? `${label}s` : 'signes'
+  return `${count} ${count === 1 ? label : plural}`
+}
 
 const parent = computed(() => props.categories.find(cat => cat.slug === props.category))
 

--- a/src/components/lexique/Category.vue
+++ b/src/components/lexique/Category.vue
@@ -23,8 +23,8 @@
         >
           <div class="card-body items-center justify-center p-4 gap-2">
             <h2 class="card-title text-lg md:text-xl text-center">{{ subcat.tag }}</h2>
-            <span class="badge badge-sm bg-base-content/10 border-0">
-              {{ signLabel(props.categoryCounts[subcat.id] ?? 0) }}
+            <span v-if="categoryCounts" class="badge badge-sm bg-base-content/10 border-0">
+              {{ signLabel(props.categoryCounts?.[subcat.id] ?? 0) }}
             </span>
           </div>
         </div>
@@ -44,7 +44,7 @@ import { useRouter, useRoute } from 'vue-router'
 const props = defineProps<{
   category: string
   categories: TCategory.TRecord[]
-  categoryCounts: Record<string, number>
+  categoryCounts?: Record<string, number>
 }>()
 const router = useRouter()
 const route = useRoute()
@@ -61,11 +61,12 @@ const subcategoryRecord = computed(() =>
 
 const subCategories = computed(() => parent.value?.expand?.category_via_Parent ?? [])
 
-const visibleSubCategories = computed(() =>
-  subCategories.value.filter(
-    (subCat: TCategory.TRecord) => (props.categoryCounts[subCat.id] ?? 0) > 0,
-  ),
-)
+const visibleSubCategories = computed(() => {
+  if (!props.categoryCounts) return subCategories.value
+  return subCategories.value.filter(
+    (subCat: TCategory.TRecord) => (props.categoryCounts![subCat.id] ?? 0) > 0,
+  )
+})
 
 function toggleSubcategory(slug: string) {
   activeSubcategory.value = activeSubcategory.value === slug ? '' : slug


### PR DESCRIPTION
## Summary

- Fix crash on lexique/culture pages when a category had no signs — `categoryCounts` was `undefined` when passed through shared components from the culture app
- Add `person_count_per_category` PocketBase view (mirrors `sign_count_per_category`, grouped by `category_id × role_id`)
- Wire up count fetching in `culture/app.vue` with the same admin vs. student logic as lexique
- Make `categoryCounts` optional in `CategoriesGrid` and `Category` — when absent, all categories are shown (culture's pre-filtered list) and count badges are hidden
- Add `entityLabel` prop to both shared components so culture displays "X personne(s)" instead of "X signe(s)"

## Test plan

- [ ] Lexique : les catégories sans signes n'apparaissent plus, les badges affichent le bon compte
- [ ] Culture : les catégories s'affichent correctement avec badge "X personne(s)"
- [ ] Vérifier que la migration PocketBase est bien appliquée sur le serveur (redémarrage PB requis)
- [ ] Tester en tant qu'étudiant (filtrage par rôle) et en tant qu'admin (compte global)