### PR TITLE
feat(outils): enrichir les champs lexicaux

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,10 +14,6 @@ Liste des petites améliorations et refactorings potentiels.
 - Quizz exécution: Ajouter un champ "à réviser" dans un signe ou une personne (cochable par utilisateur et par quizz)
 - Expression pi-sourde: créer un signe, mais le lier à une catégorie spéciale qui l'exclut du lexique et qui le met que dans les expressions pi-sourde. Pourquoi? Parce qu'on ne peut pas traduire en français. D'où l'existence de ce menu spécifique. Cela implique d'avoir un nouveau groupe de catégories pour les expressions pi-sourde.
 
-- Champ lexicaux: Dans les termes de champ lexical, il faut qu'on puisse définir si le terme est une personne. Si c'est une personne, il faut un champ supplémentaire pour une description (markdown) et 2 dates (début activité, fin activité). Il faut aussi ajouter la possibilité de lier la personne à la personne correspondante dans Culture (si elle existe).
-- Champ lexicaux: Dans la partie publique, afficher les termes sur 2 colonnes et dans la 3ème colonne, on affiche les personnes, triées par dates d'activités (tjs actives en-haut).
-- Champ lexicaux: En plus du champ description, ajouter un champ stratégie et l'afficher écrit en bleu (code couleur LSF) dans la partie publique.
-- Champ lexicaux: Gérer des catégories spécifiques pour les champs lexicaux (nouveau type de catégories)
 - Masquer le menu outil complètement aux non-admin dans la partie publique du site
 
 
@@ -63,6 +59,7 @@ Les items de "culture générale" seront aussi "recherchables" via la recherche 
 
 ## Historique (fait)
 
+- [2026-04-23] Champs lexicaux — termes enrichis (flag personne, description markdown, stratégie en bleu, dates d'activité, lien Culture) ; layout public 3 colonnes (termes sur 2 col., personnes triées par activité dans la 3e) ; catégories dédiées `lexical_field` (nouvelle entité dans admin catégories + onglet Catégories dans le formulaire champ lexical).
 - [2026-04-17] Culture — affichage du nombre de personnes par catégorie avec filtrage selon les rôles (sur le modèle des badges "N signe(s)" du lexique).
 - [2026-04-15] Admin signes — chargement limité aux 100 derniers signes modifiés (au lieu d'un `getFullList`) ; champ de recherche debounced sur nom + catégorie (retourne tous les résultats) ; tri des colonnes délégué au backend (requête PocketBase à chaque changement de tri).
 - [2026-04-15] Migration SPA Vue Lexique & Culture — `/categories/` + `/signs/` fusionnés en `/lexique/` (SPA Vue `client:only`), `/culture/` + `/persons/` fusionnés en `/culture/` avec route `/culture/person/:slug` ; toutes les requêtes PocketBase passent désormais par le token JWT de l'utilisateur connecté (role-gating uniforme). Règles de visibilité `sign`/`person` durcies côté PocketBase, vue `sign_count_per_category` ajoutée. Catégories vides masquées dans le lexique ; badges "N signe(s)" ajoutés sur les cartes catégorie/sous-catégorie.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,14 @@ Liste des petites améliorations et refactorings potentiels.
 - Culture: ajouter un mode "liste" en plus du mode (implicite) galerie actuel. Le mode liste va afficher une liste des personnes, bcp plus compacte, sans photo.
 - Quizz création: Mettre des cases à cocher et un bouton "save" au lieu du bouton "+" et du "ajouter tous"
 - Quizz exécution: Ajouter un champ "à réviser" dans un signe ou une personne (cochable par utilisateur et par quizz)
+- Expression pi-sourde: créer un signe, mais le lier à une catégorie spéciale qui l'exclut du lexique et qui le met que dans les expressions pi-sourde. Pourquoi? Parce qu'on ne peut pas traduire en français. D'où l'existence de ce menu spécifique. Cela implique d'avoir un nouveau groupe de catégories pour les expressions pi-sourde.
+
+- Champ lexicaux: Dans les termes de champ lexical, il faut qu'on puisse définir si le terme est une personne. Si c'est une personne, il faut un champ supplémentaire pour une description (markdown) et 2 dates (début activité, fin activité). Il faut aussi ajouter la possibilité de lier la personne à la personne correspondante dans Culture (si elle existe).
+- Champ lexicaux: Dans la partie publique, afficher les termes sur 2 colonnes et dans la 3ème colonne, on affiche les personnes, triées par dates d'activités (tjs actives en-haut).
+- Champ lexicaux: En plus du champ description, ajouter un champ stratégie et l'afficher écrit en bleu (code couleur LSF) dans la partie publique.
+- Champ lexicaux: Gérer des catégories spécifiques pour les champs lexicaux (nouveau type de catégories)
+- Masquer le menu outil complètement aux non-admin dans la partie publique du site
+
 
 ## Nouvelles fonctionnalités
 
@@ -33,34 +41,29 @@ Il doit avoir accès à des statistiques, des charts illustrant sa progression d
 
 Créer une espèce de trombinoscope avec des flipCards. Face A: photo. Face B: Nom + vidéo du signe s'il y en a une. L'utilité de cet outil c'est d'avoir une vue d'ensemble des infos principales des personnes et organismes, sans devoir passer par les quiz.
 
-### Migration SPA Vue — Lexique et Culture
+### Espace timeline culture générale
 
-Les pages publiques actuelles (`/categories/`, `/signs/`, `/culture/`, `/persons/`) sont des pages Astro SSR qui font des requêtes PocketBase **non authentifiées**. Avec un auth JWT stocké en `sessionStorage` (pas de session serveur), il est impossible d'appliquer un role-gating cohérent côté SSR.
+On veut un nouveau menu qui va synergiser avec tous les autres. Le but est de permettre à l'auteur du site de rentrer des informations de culture générale et de les classifier selon différents critères, notamment des dates de début et de fin si c'est un événement qui dure (2ème guerre mondiale) ou une période particulière (courant artistique) ou simplement une date d'occurrence si c'est un événement unique.
 
-Migrer en **2 SPAs Vue** (`client:only`), sur le modèle de l'admin et des pages Outils :
+On veut aussi pouvoir lier un item "culture générale" à un ou plusieurs champs lexicaux.
 
-- **SPA Lexique** : drill-down catégorie → liste de signes → détail d'un signe (`/categories/`, `/signs/`)
-- **SPA Culture** : galerie/liste de personnes et organismes → détail (`/culture/`, `/persons/`)
+On veut pouvoir y associer des signes et éventuellement des personnes/organismes de la section "culture" (qui est en fait la "culture sourde").
 
-Les deux SPAs utilisent le token JWT de l'utilisateur connecté, ce qui permet d'uniformiser le contrôle d'accès par rôles sur l'ensemble du site.
+Outre les informations de dates d'un item "culture générale", on va y trouver:
+- un nom/titre
+- une description markdown
+- des images, qu'on voudra pouvoir intégrer dans le markdown, mais qu'on uploadera séparément pour ne pas trop compliquer. Intégrées ou pas dans la descriptions, elles seront affichées en-dessous sous forme de vignettes avec la possibilité de les ouvrir en grand.
 
-Impact : retirer `@request.auth.id = ''` des `listRule`/`viewRule` des collections `sign`, `person`, `category` une fois la migration effectuée.
+Cette section "culture générale" devra s'afficher sous la forme d'une chronologie filtrable selon différent critères, à commencer les dates de début et de fin. On voudra aussi pouvoir afficher uniquement les événements à date fixe (verticalement, un peu comme la timeline d'une personne dans la rubrique "culture") ou uniquement les périodes (horizontalement, imaginer une ligne du temps avec des rectangles qui illustrent une durée et le nom de la période en-dessus). Au clic sur un élément, sa fiche détaillée apparaît sur la même page (en-dessous si on est en affichage horizontal, à droite si on est en affichage vertical).
 
-### Nouvelles sections "Outils": Champs lexicaux - Expressions françaises - Expressions pi-sourde
+On va vouloir également avoir un système d'import/export, similaire à celui qu'on a pour les signes.
 
-Ajouter un menu principal au site nommé "Outils". Dans ce menu, on pourra trouver plusieurs outils dont les 3 cités en titre. Il s'agit essentiellement d'entités qui permettent de regrouper des signes dans un certain thème.
-
-Un champ lexical se compose d'un nom (ex. "Politique"), d'un petit texte d'introduction et d'une liste de termes en français. Si un terme possède déjà un signe dans le lexique, il faudra pouvoir le lui associer.
-
-Une expression française se compose de l'expression en elle-même (ex: "Il l'a vraiment fait par dessus la jambe"), d'un champ texte "stratégies" dans lequel on peut écrire les différentes stratégies possibles pour signer cette expression et des liens vers les signes utiles.
-
-Une expression pi sourde se compose forcément d'un lien vers le signe ad-hoc (et donc sa vidéo), d'un champ texte "stratégies" dans lequel on peut écrire les différentes stratégies possibles pour retranscrire cette expression en français.
-
-Ces 3 nouvelles entités doivent apparaître dans les résultats de recherche du site.
+Les items de "culture générale" seront aussi "recherchables" via la recherche globale du site.
 
 
 ## Historique (fait)
 
+- [2026-04-17] Culture — affichage du nombre de personnes par catégorie avec filtrage selon les rôles (sur le modèle des badges "N signe(s)" du lexique).
 - [2026-04-15] Admin signes — chargement limité aux 100 derniers signes modifiés (au lieu d'un `getFullList`) ; champ de recherche debounced sur nom + catégorie (retourne tous les résultats) ; tri des colonnes délégué au backend (requête PocketBase à chaque changement de tri).
 - [2026-04-15] Migration SPA Vue Lexique & Culture — `/categories/` + `/signs/` fusionnés en `/lexique/` (SPA Vue `client:only`), `/culture/` + `/persons/` fusionnés en `/culture/` avec route `/culture/person/:slug` ; toutes les requêtes PocketBase passent désormais par le token JWT de l'utilisateur connecté (role-gating uniforme). Règles de visibilité `sign`/`person` durcies côté PocketBase, vue `sign_count_per_category` ajoutée. Catégories vides masquées dans le lexique ; badges "N signe(s)" ajoutés sur les cartes catégorie/sous-catégorie.
 - [2026-04-14] Section "Outils" — nouveau menu principal avec 3 entités : Champs lexicaux (nom + intro + liste de termes liables aux signes), Expressions françaises (expression + stratégies + signes utiles), Expressions pi-sourdes (signe ad-hoc + vidéo + stratégies) ; CRUD admin complet, pages publiques SSR, intégration dans la recherche globale. Correctif simultané : le picker de signe dans l'admin passe d'un dropdown chargé en masse à une recherche à la frappe (`SignPicker.vue`).

--- a/pb/pb_migrations/1776500001_updated_lexical_term.js
+++ b/pb/pb_migrations/1776500001_updated_lexical_term.js
@@ -1,0 +1,105 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId('pbc_4001000002')
+
+  // is_person
+  collection.fields.addAt(4, new Field({
+    "hidden": false,
+    "id": "bool4001000026",
+    "name": "is_person",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // description (markdown)
+  collection.fields.addAt(5, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text4001000027",
+    "max": 0,
+    "min": 0,
+    "name": "description",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // strategy
+  collection.fields.addAt(6, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text4001000028",
+    "max": 0,
+    "min": 0,
+    "name": "strategy",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // start_date
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text4001000029",
+    "max": 0,
+    "min": 0,
+    "name": "start_date",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // end_date
+  collection.fields.addAt(8, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text4001000030",
+    "max": 0,
+    "min": 0,
+    "name": "end_date",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // Person (relation to person collection)
+  collection.fields.addAt(9, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_63941688",
+    "hidden": false,
+    "id": "relation4001000031",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "Person",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "relation"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId('pbc_4001000002')
+  collection.fields.removeById('bool4001000026')
+  collection.fields.removeById('text4001000027')
+  collection.fields.removeById('text4001000028')
+  collection.fields.removeById('text4001000029')
+  collection.fields.removeById('text4001000030')
+  collection.fields.removeById('relation4001000031')
+  return app.save(collection)
+})

--- a/pb/pb_migrations/1776500002_updated_category.js
+++ b/pb/pb_migrations/1776500002_updated_category.js
@@ -1,0 +1,41 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId('pbc_1174553048')
+
+  collection.fields.addAt(4, new Field({
+    "hidden": false,
+    "id": "select1357669605",
+    "maxSelect": 3,
+    "name": "entities",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "person",
+      "activity",
+      "lexical_field"
+    ]
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId('pbc_1174553048')
+
+  collection.fields.addAt(4, new Field({
+    "hidden": false,
+    "id": "select1357669605",
+    "maxSelect": 2,
+    "name": "entities",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "person",
+      "activity"
+    ]
+  }))
+
+  return app.save(collection)
+})

--- a/pb/pb_migrations/1776500003_updated_lexical_field.js
+++ b/pb/pb_migrations/1776500003_updated_lexical_field.js
@@ -1,0 +1,24 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId('pbc_4001000001')
+
+  collection.fields.addAt(5, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_1174553048",
+    "hidden": false,
+    "id": "relation4001000017",
+    "maxSelect": 999,
+    "minSelect": 0,
+    "name": "Categories",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "relation"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId('pbc_4001000001')
+  collection.fields.removeById('relation4001000017')
+  return app.save(collection)
+})

--- a/src/admin/components/LexicalFieldAddModal.vue
+++ b/src/admin/components/LexicalFieldAddModal.vue
@@ -27,7 +27,7 @@ const { addLexicalField } = useLexicalFields()
 const { addTerm } = useLexicalTerms()
 const saving = ref(false)
 
-const form = ref<TLexicalField.TForm>({ name: '', introduction: '', Roles: [] })
+const form = ref<TLexicalField.TForm>({ name: '', introduction: '', Roles: [], Categories: [] })
 const terms = ref<LocalTerm[]>([])
 
 const save = async () => {
@@ -36,12 +36,22 @@ const save = async () => {
     const field = await addLexicalField(form.value) as any
     for (const t of terms.value) {
       if (t.term.trim()) {
-        await addTerm({ term: t.term, LexicalField: field.id, Sign: t.Sign || undefined })
+        await addTerm({
+          term: t.term,
+          LexicalField: field.id,
+          Sign: t.Sign || undefined,
+          is_person: t.is_person,
+          description: t.description,
+          strategy: t.strategy,
+          start_date: t.start_date,
+          end_date: t.end_date,
+          Person: t.Person || undefined,
+        })
       }
     }
     emit('saved')
     visible.value = false
-    form.value = { name: '', introduction: '', Roles: [] }
+    form.value = { name: '', introduction: '', Roles: [], Categories: [] }
     terms.value = []
   } finally {
     saving.value = false

--- a/src/admin/components/LexicalFieldEditModal.vue
+++ b/src/admin/components/LexicalFieldEditModal.vue
@@ -29,7 +29,7 @@ const { loadLexicalField, updateLexicalField } = useLexicalFields()
 const { loadTermsByField, addTerm, updateTerm, deleteTerm } = useLexicalTerms()
 const saving = ref(false)
 
-const form = ref<TLexicalField.TForm>({ name: '', introduction: '', Roles: [] })
+const form = ref<TLexicalField.TForm>({ name: '', introduction: '', Roles: [], Categories: [] })
 const terms = ref<LocalTerm[]>([])
 const originalTermIds = ref<string[]>([])
 
@@ -42,9 +42,20 @@ watch(visible, async (isVisible) => {
     slug: field.slug,
     introduction: field.introduction || '',
     Roles: field.Roles || [],
+    Categories: field.Categories || [],
   }
   const loaded = await loadTermsByField(props.fieldId)
-  terms.value = loaded.map(t => ({ id: t.id, term: t.term, Sign: t.Sign || '' }))
+  terms.value = loaded.map(t => ({
+    id: t.id,
+    term: t.term,
+    Sign: t.Sign || '',
+    is_person: t.is_person || false,
+    description: t.description || '',
+    strategy: t.strategy || '',
+    start_date: t.start_date || '',
+    end_date: t.end_date || '',
+    Person: t.Person || '',
+  }))
   originalTermIds.value = loaded.map(t => t.id)
 }, { immediate: true })
 
@@ -63,10 +74,21 @@ const save = async () => {
     // Create or update
     for (const t of terms.value) {
       if (!t.term.trim()) continue
+      const payload = {
+        term: t.term,
+        LexicalField: props.fieldId,
+        Sign: t.Sign || undefined,
+        is_person: t.is_person,
+        description: t.description,
+        strategy: t.strategy,
+        start_date: t.start_date,
+        end_date: t.end_date,
+        Person: t.Person || undefined,
+      }
       if (t.id) {
-        await updateTerm(t.id, { term: t.term, LexicalField: props.fieldId, Sign: t.Sign || undefined })
+        await updateTerm(t.id, payload)
       } else {
-        await addTerm({ term: t.term, LexicalField: props.fieldId, Sign: t.Sign || undefined })
+        await addTerm(payload)
       }
     }
 

--- a/src/admin/components/LexicalFieldForm.vue
+++ b/src/admin/components/LexicalFieldForm.vue
@@ -1,123 +1,242 @@
 <template>
-  <div class="space-y-4">
-    <!-- Nom -->
-    <div class="flex items-center gap-4">
-      <label for="lf-name" class="font-semibold w-60">Nom</label>
-      <InputText v-model="form.name" id="lf-name" class="w-full" required />
-    </div>
+  <Tabs v-model:value="activeTab" class="w-full">
+    <TabList>
+      <Tab :value="0">Informations</Tab>
+      <Tab :value="1">Termes</Tab>
+      <Tab :value="2">Catégories</Tab>
+    </TabList>
 
-    <!-- Slug -->
-    <div class="flex items-center gap-4">
-      <label for="lf-slug" class="font-semibold w-60">Slug</label>
-      <div class="flex gap-2 w-full">
-        <InputText
-          v-model="form.slug"
-          id="lf-slug"
-          class="flex-1"
-          placeholder="Auto-généré depuis le nom"
-        />
-        <Button
-          icon="i-fa6-solid-arrows-rotate"
-          severity="secondary"
-          size="small"
-          @click="regenerateSlug"
-          v-tooltip="'Régénérer depuis le nom'"
-        />
-      </div>
-    </div>
+    <TabPanels>
+      <!-- Onglet Informations -->
+      <TabPanel :value="0" class="space-y-4">
+        <!-- Nom -->
+        <div class="flex items-center gap-4">
+          <label for="lf-name" class="font-semibold w-60">Nom</label>
+          <InputText v-model="form.name" id="lf-name" class="w-full" required />
+        </div>
 
-    <!-- Introduction -->
-    <div class="flex items-start gap-4">
-      <label for="lf-intro" class="font-semibold w-60 pt-2">Introduction</label>
-      <textarea
-        v-model="form.introduction"
-        id="lf-intro"
-        class="textarea textarea-bordered w-full"
-        rows="3"
-        placeholder="Courte description du champ lexical..."
-      ></textarea>
-    </div>
+        <!-- Slug -->
+        <div class="flex items-center gap-4">
+          <label for="lf-slug" class="font-semibold w-60">Slug</label>
+          <div class="flex gap-2 w-full">
+            <InputText
+              v-model="form.slug"
+              id="lf-slug"
+              class="flex-1"
+              placeholder="Auto-généré depuis le nom"
+            />
+            <Button
+              icon="i-fa6-solid-arrows-rotate"
+              severity="secondary"
+              size="small"
+              @click="regenerateSlug"
+              v-tooltip="'Régénérer depuis le nom'"
+            />
+          </div>
+        </div>
 
-    <!-- Visible pour (rôles) -->
-    <div class="flex items-center gap-4">
-      <label class="font-semibold w-60">Visible pour</label>
-      <div class="flex flex-wrap gap-2 w-full">
-        <span v-if="rolesLoading" class="loading loading-spinner loading-sm"></span>
-        <template v-else>
-          <button
-            v-for="role in roles"
-            :key="role.id"
-            type="button"
-            class="badge badge-md"
-            :class="roleBadgeClass(role)"
-            :title="role.slug === 'admin' ? 'Toujours autorisé (automatique)' : ''"
-            @click="toggleRole(role)"
-          >
-            {{ role.name }}
-            <span v-if="role.slug === 'admin'" class="ml-1 i-fa6-solid-lock text-xs"></span>
-          </button>
-        </template>
-      </div>
-    </div>
+        <!-- Introduction -->
+        <div class="flex items-start gap-4">
+          <label for="lf-intro" class="font-semibold w-60 pt-2">Introduction</label>
+          <textarea
+            v-model="form.introduction"
+            id="lf-intro"
+            class="textarea textarea-bordered w-full"
+            rows="3"
+            placeholder="Courte description du champ lexical..."
+          ></textarea>
+        </div>
 
-    <!-- Termes -->
-    <div class="flex items-start gap-4">
-      <label class="font-semibold w-60 pt-2">Termes</label>
-      <div class="w-full space-y-2">
+        <!-- Visible pour (rôles) -->
+        <div class="flex items-center gap-4">
+          <label class="font-semibold w-60">Visible pour</label>
+          <div class="flex flex-wrap gap-2 w-full">
+            <span v-if="rolesLoading" class="loading loading-spinner loading-sm"></span>
+            <template v-else>
+              <button
+                v-for="role in roles"
+                :key="role.id"
+                type="button"
+                class="badge badge-md"
+                :class="roleBadgeClass(role)"
+                :title="role.slug === 'admin' ? 'Toujours autorisé (automatique)' : ''"
+                @click="toggleRole(role)"
+              >
+                {{ role.name }}
+                <span v-if="role.slug === 'admin'" class="ml-1 i-fa6-solid-lock text-xs"></span>
+              </button>
+            </template>
+          </div>
+        </div>
+      </TabPanel>
+
+      <!-- Onglet Termes -->
+      <TabPanel :value="1" class="space-y-3">
         <div
           v-for="(termItem, index) in terms"
           :key="index"
-          class="flex items-start gap-2 p-3 border border-base-300 rounded-lg"
+          class="p-4 border border-base-300 rounded-lg space-y-3"
         >
-          <div class="flex-1 space-y-2">
-            <InputText
-              v-model="termItem.term"
-              class="w-full"
-              placeholder="Terme français..."
-            />
-            <div>
-              <p class="text-xs text-base-content/50 mb-1">Signe associé (optionnel)</p>
-              <SignPicker mode="single" v-model="termItem.Sign" />
+          <div class="flex items-start gap-2">
+            <div class="flex-1 space-y-3">
+              <!-- Terme -->
+              <InputText
+                v-model="termItem.term"
+                class="w-full"
+                placeholder="Terme français..."
+              />
+
+              <!-- Est une personne -->
+              <div class="flex items-center gap-3">
+                <ToggleSwitch v-model="termItem.is_person" :inputId="`term-is-person-${index}`" />
+                <label :for="`term-is-person-${index}`" class="text-sm cursor-pointer">
+                  Ce terme est une personne
+                </label>
+              </div>
+
+              <!-- Stratégie (toujours visible) -->
+              <div>
+                <p class="text-xs text-base-content/50 mb-1">Stratégie (optionnel)</p>
+                <textarea
+                  v-model="termItem.strategy"
+                  class="textarea textarea-bordered w-full text-sm"
+                  rows="2"
+                  placeholder="Stratégie..."
+                ></textarea>
+              </div>
+
+              <!-- Signe associé (toujours visible) -->
+              <div>
+                <p class="text-xs text-base-content/50 mb-1">Signe associé (optionnel)</p>
+                <SignPicker mode="single" v-model="termItem.Sign" />
+              </div>
+
+              <!-- Champs spécifiques personne -->
+              <template v-if="termItem.is_person">
+                <div>
+                  <p class="text-xs text-base-content/50 mb-1">Description (markdown)</p>
+                  <textarea
+                    v-model="termItem.description"
+                    class="textarea textarea-bordered w-full text-sm"
+                    rows="4"
+                    placeholder="Description de la personne..."
+                  ></textarea>
+                </div>
+
+                <div class="grid grid-cols-2 gap-3">
+                  <div>
+                    <p class="text-xs text-base-content/50 mb-1">Début d'activité</p>
+                    <InputText
+                      v-model="termItem.start_date"
+                      type="date"
+                      class="w-full text-sm"
+                    />
+                  </div>
+                  <div>
+                    <p class="text-xs text-base-content/50 mb-1">Fin d'activité</p>
+                    <InputText
+                      v-model="termItem.end_date"
+                      type="date"
+                      class="w-full text-sm"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <p class="text-xs text-base-content/50 mb-1">Personne liée dans Culture (optionnel)</p>
+                  <PersonPicker v-model="termItem.Person" />
+                </div>
+              </template>
             </div>
+
+            <button
+              type="button"
+              class="btn btn-square btn-sm btn-error btn-outline mt-1 shrink-0"
+              @click="removeTerm(index)"
+            >
+              <span class="i-fa-solid-times"></span>
+            </button>
           </div>
-          <button
-            type="button"
-            class="btn btn-square btn-sm btn-error btn-outline mt-1"
-            @click="removeTerm(index)"
-          >
-            <span class="i-fa-solid-times"></span>
-          </button>
         </div>
 
         <button type="button" class="btn btn-sm btn-outline" @click="addTerm">
           <span class="i-fa-solid-plus"></span>
           Ajouter un terme
         </button>
-      </div>
-    </div>
-  </div>
+      </TabPanel>
+
+      <!-- Onglet Catégories -->
+      <TabPanel :value="2">
+        <CategoriesPickerForm
+          v-model="selectedCategories"
+          entity="lexical_field"
+        />
+      </TabPanel>
+    </TabPanels>
+  </Tabs>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import InputText from 'primevue/inputtext'
 import Button from 'primevue/button'
+import Tabs from 'primevue/tabs'
+import TabList from 'primevue/tablist'
+import Tab from 'primevue/tab'
+import TabPanels from 'primevue/tabpanels'
+import TabPanel from 'primevue/tabpanel'
+import ToggleSwitch from 'primevue/toggleswitch'
 import useRoles from '../composables/useRoles'
+import useCategories from '../composables/useCategories'
 import type { TLexicalField } from '../../types'
 import SignPicker from './SignPicker.vue'
+import PersonPicker from './PersonPicker.vue'
+import CategoriesPickerForm from './CategoriesPickerForm.vue'
 import { createSlug } from '@admin/helpers/strings'
 
 export type LocalTerm = {
   id?: string
   term: string
   Sign?: string
+  is_person?: boolean
+  description?: string
+  strategy?: string
+  start_date?: string
+  end_date?: string
+  Person?: string
 }
 
 const form = defineModel<TLexicalField.TForm>({ required: true })
 const terms = defineModel<LocalTerm[]>('terms', { required: true })
 
+const activeTab = ref(0)
 const { roles, loadRoles } = useRoles()
+const { categories, loadCategories } = useCategories()
 const rolesLoading = ref(false)
+
+// selectedCategories: { [parentId]: childId[] }
+const selectedCategories = ref<{ [parentId: string]: string[] }>({})
+const categoriesInitialized = ref(false)
+
+// When categories load, initialize selectedCategories from form.Categories (edit mode)
+watch([categories, () => form.value.Categories], () => {
+  if (categoriesInitialized.value) return
+  if (!categories.value.length) return
+  categoriesInitialized.value = true
+  const flatIds = form.value.Categories || []
+  const result: { [parentId: string]: string[] } = {}
+  for (const parent of categories.value.filter((c: any) => !c.Parent)) {
+    const children = (parent.expand?.category_via_Parent || []) as any[]
+    result[parent.id] = children.filter((c: any) => flatIds.includes(c.id)).map((c: any) => c.id)
+  }
+  selectedCategories.value = result
+}, { immediate: true })
+
+// Sync selectedCategories → form.Categories
+watch(selectedCategories, (val) => {
+  if (!categoriesInitialized.value) return
+  form.value.Categories = Object.values(val).flat()
+}, { deep: true })
 
 const adminRoleId = ref('')
 watch(roles, () => {
@@ -159,7 +278,7 @@ watch(() => form.value.name, (val) => {
 })
 
 const addTerm = () => {
-  terms.value = [...terms.value, { term: '', Sign: '' }]
+  terms.value = [...terms.value, { term: '', Sign: '', is_person: false }]
 }
 
 const removeTerm = (index: number) => {
@@ -168,8 +287,7 @@ const removeTerm = (index: number) => {
 
 onMounted(() => {
   rolesLoading.value = true
-  loadRoles().finally(() => {
-    rolesLoading.value = false
-  })
+  loadRoles().finally(() => (rolesLoading.value = false))
+  loadCategories('lexical_field')
 })
 </script>

--- a/src/admin/components/PersonPicker.vue
+++ b/src/admin/components/PersonPicker.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="space-y-2">
+    <!-- Selected item -->
+    <div v-if="selectedItem" class="flex flex-wrap gap-2">
+      <span class="badge badge-primary gap-1">
+        {{ selectedItem.label }}
+        <button type="button" @click="remove" class="hover:opacity-70">
+          <span class="i-fa-solid-times text-xs"></span>
+        </button>
+      </span>
+    </div>
+
+    <!-- Search input (hidden when a value is selected) -->
+    <div v-if="!selectedItem" class="relative">
+      <InputText
+        v-model="searchTerm"
+        class="w-full"
+        placeholder="Rechercher une personne..."
+        autocomplete="off"
+      />
+
+      <!-- Results dropdown -->
+      <div
+        v-if="searchResults.length > 0"
+        class="absolute z-50 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-48 overflow-y-auto"
+      >
+        <button
+          v-for="result in searchResults"
+          :key="result.id"
+          type="button"
+          class="flex items-center w-full px-3 py-2 text-left hover:bg-base-200 transition-colors text-sm"
+          @click="select(result)"
+        >
+          {{ result.label }}
+        </button>
+      </div>
+
+      <!-- Loading -->
+      <span
+        v-if="searching"
+        class="absolute right-3 top-1/2 -translate-y-1/2 loading loading-spinner loading-xs"
+      ></span>
+
+      <!-- No results -->
+      <div
+        v-if="searchTerm.length >= 2 && !searching && searchResults.length === 0"
+        class="absolute z-50 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-sm p-3 text-sm text-base-content/50"
+      >
+        Aucune personne trouvée
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue'
+import InputText from 'primevue/inputtext'
+import PocketBase from 'pocketbase'
+import config from '../../config'
+
+type PersonItem = { id: string; label: string }
+
+const model = defineModel<string>()
+
+const pb = new PocketBase(config.apiBaseUrl)
+
+const searchTerm = ref('')
+const searchResults = ref<PersonItem[]>([])
+const selectedItem = ref<PersonItem | null>(null)
+const searching = ref(false)
+
+const buildLabel = (p: any) =>
+  p.firstname ? `${p.firstname} ${p.name}` : p.name
+
+onMounted(async () => {
+  if (!model.value) return
+  const res = await pb.collection('person').getOne(model.value, { fields: 'id,name,firstname' })
+  selectedItem.value = { id: res.id, label: buildLabel(res) }
+})
+
+let debounceTimer: ReturnType<typeof setTimeout>
+watch(searchTerm, (val) => {
+  clearTimeout(debounceTimer)
+  if (val.length < 2) {
+    searchResults.value = []
+    return
+  }
+  debounceTimer = setTimeout(async () => {
+    searching.value = true
+    try {
+      const res = await pb.collection('person').getList(1, 10, {
+        filter: `name~"${val}" || firstname~"${val}"`,
+        fields: 'id,name,firstname',
+        sort: 'name,firstname',
+      })
+      searchResults.value = res.items.map((p: any) => ({ id: p.id, label: buildLabel(p) }))
+    } finally {
+      searching.value = false
+    }
+  }, 300)
+})
+
+const select = (item: PersonItem) => {
+  selectedItem.value = item
+  model.value = item.id
+  searchTerm.value = ''
+  searchResults.value = []
+}
+
+const remove = () => {
+  selectedItem.value = null
+  model.value = ''
+}
+</script>

--- a/src/admin/composables/useLexicalFields.ts
+++ b/src/admin/composables/useLexicalFields.ts
@@ -15,6 +15,12 @@ const setFormData = (payload: TLexicalField.TForm) => {
   if ((payload.Roles || []).length === 0) {
     formData.append('Roles', '')
   }
+  ;(payload.Categories || []).forEach(catId => {
+    formData.append('Categories', catId)
+  })
+  if ((payload.Categories || []).length === 0) {
+    formData.append('Categories', '')
+  }
   return formData
 }
 
@@ -40,7 +46,7 @@ export default function useLexicalFields() {
 
   const loadLexicalField = async (id: string) => {
     return pb.collection<TLexicalField.TRecord>('lexical_field').getOne(id, {
-      expand: 'Roles',
+      expand: 'Roles,Categories',
     })
   }
 

--- a/src/admin/composables/useLexicalTerms.ts
+++ b/src/admin/composables/useLexicalTerms.ts
@@ -11,28 +11,32 @@ export default function useLexicalTerms() {
   const loadTermsByField = async (lexicalFieldId: string) => {
     terms.value = await pb.collection<TLexicalTerm.TRecord>('lexical_term').getFullList({
       filter: `LexicalField = "${lexicalFieldId}"`,
-      expand: 'Sign',
+      expand: 'Sign,Person',
       sort: 'term',
     })
     return terms.value
   }
 
-  const addTerm = async (payload: TLexicalTerm.TForm) => {
-    const formData = new FormData()
-    formData.append('term', payload.term.trim())
-    formData.append('LexicalField', payload.LexicalField)
-    if (payload.Sign) {
-      formData.append('Sign', payload.Sign)
-    }
-    return pb.collection('lexical_term').create(formData)
-  }
-
-  const updateTerm = async (id: string, payload: TLexicalTerm.TForm) => {
+  const buildFormData = (payload: TLexicalTerm.TForm) => {
     const formData = new FormData()
     formData.append('term', payload.term.trim())
     formData.append('LexicalField', payload.LexicalField)
     formData.append('Sign', payload.Sign || '')
-    return pb.collection('lexical_term').update(id, formData)
+    formData.append('is_person', String(Boolean(payload.is_person)))
+    formData.append('description', payload.description || '')
+    formData.append('strategy', payload.strategy || '')
+    formData.append('start_date', payload.start_date || '')
+    formData.append('end_date', payload.end_date || '')
+    formData.append('Person', payload.Person || '')
+    return formData
+  }
+
+  const addTerm = async (payload: TLexicalTerm.TForm) => {
+    return pb.collection('lexical_term').create(buildFormData(payload))
+  }
+
+  const updateTerm = async (id: string, payload: TLexicalTerm.TForm) => {
+    return pb.collection('lexical_term').update(id, buildFormData(payload))
   }
 
   const deleteTerm = async (id: string) => {

--- a/src/admin/config/entities.ts
+++ b/src/admin/config/entities.ts
@@ -2,6 +2,7 @@
 export const ENTITY_OPTIONS = [
   { id: 'person', label: 'Personnes', disabled: false },
   { id: 'activity', label: 'Activités', disabled: false },
+  { id: 'lexical_field', label: 'Champs lexicaux', disabled: false },
 ]
 
 export const ALL_ENTITIES = [{ id: 'sign', label: 'Signes', disabled: true }, ...ENTITY_OPTIONS]

--- a/src/components/outils/LexicalFieldDetail.vue
+++ b/src/components/outils/LexicalFieldDetail.vue
@@ -10,25 +10,69 @@
       <h1 class="text-3xl font-bold mb-2">{{ field.name }}</h1>
       <p v-if="field.introduction" class="text-base-content/70 mb-8 max-w-2xl">{{ field.introduction }}</p>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        <div v-for="term in terms" :key="term.id" class="card card-border p-4">
-          <span class="font-medium">{{ term.term }}</span>
-          <a
-            v-if="term.expand?.Sign"
-            :href="`/lexique/sign/${term.expand.Sign.slug}`"
-            class="text-sm text-primary hover:underline mt-1 block"
-          >
-            → Voir le signe : {{ term.expand.Sign.name }}
-          </a>
+      <div v-if="regularTerms.length === 0 && personTerms.length === 0" class="text-center text-base-content/50 py-16">
+        Aucun terme dans ce champ lexical.
+      </div>
+
+      <div v-else class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Colonnes 1 & 2 : termes réguliers -->
+        <div class="lg:col-span-2">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div v-for="term in regularTerms" :key="term.id" class="card card-border p-4 space-y-1">
+              <span class="font-medium">{{ term.term }}</span>
+              <p v-if="term.strategy" class="text-sm text-blue-600">{{ term.strategy }}</p>
+              <a
+                v-if="term.expand?.Sign"
+                :href="`/lexique/sign/${term.expand.Sign.slug}`"
+                class="text-sm text-primary hover:underline block"
+              >
+                → Voir le signe : {{ term.expand.Sign.name }}
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Colonne 3 : personnes -->
+        <div v-if="personTerms.length > 0" class="space-y-4">
+          <h2 class="text-lg font-semibold text-base-content/70">Personnes</h2>
+          <div v-for="term in personTerms" :key="term.id" class="card card-border p-4 space-y-2">
+            <div class="flex items-center gap-2">
+              <span class="font-medium">{{ term.term }}</span>
+              <span v-if="isActive(term)" class="badge badge-success badge-sm">actif</span>
+            </div>
+
+            <div v-if="term.start_date || term.end_date" class="text-xs text-base-content/50">
+              {{ formatDateRange(term.start_date, term.end_date) }}
+            </div>
+
+            <p v-if="term.strategy" class="text-sm text-blue-600">{{ term.strategy }}</p>
+            <p v-if="term.description" class="text-sm text-base-content/70">{{ term.description }}</p>
+
+            <div class="flex gap-2 flex-wrap">
+              <a
+                v-if="term.expand?.Person"
+                :href="`/culture/person/${term.expand.Person.slug}`"
+                class="text-sm text-primary hover:underline"
+              >
+                → Fiche Culture
+              </a>
+              <a
+                v-if="term.expand?.Sign"
+                :href="`/lexique/sign/${term.expand.Sign.slug}`"
+                class="text-sm text-primary hover:underline"
+              >
+                → Voir le signe
+              </a>
+            </div>
+          </div>
         </div>
       </div>
-      <p v-if="terms.length === 0" class="text-center text-base-content/50 py-16">Aucun terme dans ce champ lexical.</p>
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import useAuth from '@admin/composables/useAuth'
 
 const props = defineProps<{ slug: string }>()
@@ -48,11 +92,40 @@ onMounted(async () => {
     field.value = await pb.collection('lexical_field').getFirstListItem(`slug="${props.slug}"`)
     terms.value = await pb.collection('lexical_term').getFullList({
       filter: `LexicalField = "${field.value.id}"`,
-      expand: 'Sign',
+      expand: 'Sign,Person',
       sort: 'term',
     })
   } finally {
     loading.value = false
   }
 })
+
+const regularTerms = computed(() => terms.value.filter((t: any) => !t.is_person))
+
+const personTerms = computed(() => {
+  const persons = terms.value.filter((t: any) => t.is_person)
+  return persons.sort((a: any, b: any) => {
+    const aActive = isActive(a)
+    const bActive = isActive(b)
+    if (aActive !== bActive) return aActive ? -1 : 1
+    // Both active or both inactive: sort by start_date desc
+    if (a.start_date && b.start_date) return b.start_date.localeCompare(a.start_date)
+    if (a.start_date) return -1
+    if (b.start_date) return 1
+    return a.term.localeCompare(b.term)
+  })
+})
+
+const isActive = (term: any) => {
+  if (!term.end_date) return true
+  return new Date(term.end_date) >= new Date()
+}
+
+const formatDateRange = (start: string, end: string) => {
+  const parts = []
+  if (start) parts.push(new Date(start).getFullYear())
+  if (end) parts.push(new Date(end).getFullYear())
+  else if (start) parts.push('présent')
+  return parts.join(' – ')
+}
 </script>

--- a/src/types/lexical-field.ts
+++ b/src/types/lexical-field.ts
@@ -6,8 +6,10 @@ export type TRecord = {
   slug: string
   introduction: string
   Roles: string[]
+  Categories: string[]
   expand?: {
     Roles?: Array<{ id: string; name: string; slug: string }>
+    Categories?: Array<{ id: string; tag: string; Parent: string }>
   }
   created: string
   updated: string
@@ -19,4 +21,5 @@ export type TForm = {
   slug?: string
   introduction: string
   Roles: string[]
+  Categories: string[]
 }

--- a/src/types/lexical-term.ts
+++ b/src/types/lexical-term.ts
@@ -3,8 +3,15 @@ export type TRecord = {
   term: string
   LexicalField: string
   Sign: string
+  is_person: boolean
+  description: string
+  strategy: string
+  start_date: string
+  end_date: string
+  Person: string
   expand?: {
     Sign?: { id: string; name: string; slug: string }
+    Person?: { id: string; name: string; firstname: string; slug: string }
   }
   created: string
   updated: string
@@ -15,4 +22,10 @@ export type TForm = {
   term: string
   LexicalField: string
   Sign?: string
+  is_person?: boolean
+  description?: string
+  strategy?: string
+  start_date?: string
+  end_date?: string
+  Person?: string
 }


### PR DESCRIPTION
## Résumé

Enrichissement complet de la section **Champs lexicaux** :

- **Termes-personnes** — chaque terme peut être marqué comme personne, avec description (markdown), champ stratégie, dates d'activité (début/fin) et lien optionnel vers une fiche Culture existante
- **Stratégie** — champ stratégie disponible sur tous les termes, affiché en bleu côté public (code couleur LSF)
- **Catégories dédiées** — nouveau type d'entité `lexical_field` dans l'admin des catégories ; formulaire champ lexical restructuré en 3 onglets (Informations / Termes / Catégories)
- **Layout public** — refonte en 3 colonnes : termes réguliers sur 2 colonnes, personnes dans la 3e triées par dates d'activité (actives en haut)

## Changements techniques

- 3 migrations PocketBase (`lexical_term` +6 champs, `category.entities` +valeur, `lexical_field` +relation `Categories`)
- Nouveau composant `PersonPicker.vue` (recherche à la frappe sur la collection `person`)
- Types TypeScript mis à jour (`TLexicalTerm`, `TLexicalField`)
- Composables `useLexicalTerms` et `useLexicalFields` mis à jour

## Plan de test

- [ ] Appliquer les migrations PocketBase (`./pocketbase migrate up`)
- [ ] Créer une catégorie avec l'entité "Champs lexicaux" dans l'admin
- [ ] Créer/éditer un champ lexical : vérifier les 3 onglets et l'assignation de catégories
- [ ] Ajouter un terme standard avec une stratégie, vérifier l'affichage en bleu côté public
- [ ] Ajouter un terme-personne avec dates + lien Culture, vérifier le tri dans la 3e colonne